### PR TITLE
gcm: update for 2.4.0 GCM structure

### DIFF
--- a/source/deimos/isal_crypto/aes_gcm.d
+++ b/source/deimos/isal_crypto/aes_gcm.d
@@ -158,6 +158,7 @@ align(16) struct gcm_key_data
     ubyte[GCM_ENC_KEY_LEN] shifted_hkey_6_k; // store XOR of High 64 bits and Low 64 bits of  HashKey^6 <<1 mod poly here (for Karatsuba purposes)
     ubyte[GCM_ENC_KEY_LEN] shifted_hkey_7_k; // store XOR of High 64 bits and Low 64 bits of  HashKey^7 <<1 mod poly here (for Karatsuba purposes)
     ubyte[GCM_ENC_KEY_LEN] shifted_hkey_8_k; // store XOR of High 64 bits and Low 64 bits of  HashKey^8 <<1 mod poly here (for Karatsuba purposes)
+    ubyte[GCM_ENC_KEY_LEN * (48-16)] shifted_hkey_n_k; // Note, this assumes ISA-L built without GCM_BIG_DATA (use 128 instead of 48 for GCM_BIG_DATA)
 }
 
 /**


### PR DESCRIPTION
This fixes an overrun when setting up the key schedule, where the C code will overrun the key schedule clobbering anything after it in the stack (corruption.)

I found this while running the unittest for GCM on ARM.  I guess we got lucky on x86.

It appears that GCM_BIG_DATA could be even bigger, but nothing in 2.4.0 seems to define that -- it seems to be something intended for AVX-512, but we don't use AVX-512 with GCM right now.